### PR TITLE
IDT websocket freshness: in-process IDT registry + CaptureIDTMiddleware

### DIFF
--- a/pkg/gofiber-session/gofiber-session.go
+++ b/pkg/gofiber-session/gofiber-session.go
@@ -173,6 +173,23 @@ func AuthRequire(config Config) fiber.Handler {
 
 var openResourceRegexp *regexp.Regexp
 
+// CaptureIDTMiddleware records the proxy-injected TRX_IDT header into the
+// in-process IDT registry on every request, keyed by the gofiber session id.
+// Reusable across any webapp behind the proxy: app.Use(CaptureIDTMiddleware(sess)).
+// No-op when no IDT header is present (IDT off / non-IDT request). Read-only with
+// respect to the session — it only reads store.ID(); it never mutates the session.
+// Register it AFTER AuthorizationProxyCheck so the session cookie is resolvable.
+func CaptureIDTMiddleware(session *session.Session) fiber.Handler {
+	return func(ctx *fiber.Ctx) error {
+		if idt := ReadIDT(ctx); idt != "" && session != nil {
+			if store := session.Get(ctx); store != nil {
+				CaptureIDT(store.ID(), idt)
+			}
+		}
+		return ctx.Next()
+	}
+}
+
 func AuthorizationProxyCheck(session *session.Session) fiber.Handler {
 	var combinedOpenResourcePatternsEnv = os.Getenv("OPEN_RESOURCE_PATTERNS")
 	combinedOpenResourcePatterns := ".*/gxt/.*|.*nocache.*|.*\\.cache\\..*|.*\\/bootstrap\\.min\\..*|angular\\.min\\.js|.*\\/zapatec\\/.*\\..*|.*\\/pdfjs\\/.*\\.js(?:\\?.*)?$|.*\\.(jpg|jpeg|png|gif|svg|woff2|woff|ttf)(?:\\?.*)?$|.*\\.css(?:\\?.*)?$|.*\\.map(?:\\?.*)?$" // .*\.js(?:\?.*)?$

--- a/pkg/gofiber-session/idtregistry.go
+++ b/pkg/gofiber-session/idtregistry.go
@@ -1,0 +1,64 @@
+package gofiber_session
+
+import (
+	"sync"
+	"time"
+)
+
+// idtRegistry holds the most-recent IDT per gofiber session id. The proxy
+// injects a fresh TRX_IDT header on every forwarded request; a webapp captures
+// it here so a long-lived WebSocket can read the *current* IDT at publish time
+// instead of a token frozen at handshake. In-process is sufficient because the
+// ALB pins a browser's traffic and its socket to the same task (sticky sessions).
+type idtEntry struct {
+	idt     string
+	updated time.Time
+}
+
+var idtRegistry = struct {
+	sync.RWMutex
+	m map[string]idtEntry
+}{m: make(map[string]idtEntry)}
+
+// idtRegistryMaxAge bounds memory if a session never calls ForgetIDT (e.g. the
+// process was killed mid-socket). Entries older than this are swept lazily.
+const idtRegistryMaxAge = 2 * time.Hour
+
+// CaptureIDT records idt as the current token for sessionID. No-op if either is
+// empty (IDT off / non-IDT request).
+func CaptureIDT(sessionID, idt string) {
+	if sessionID == "" || idt == "" {
+		return
+	}
+	now := time.Now()
+	idtRegistry.Lock()
+	idtRegistry.m[sessionID] = idtEntry{idt: idt, updated: now}
+	// Opportunistic sweep so the map stays bounded.
+	for k, e := range idtRegistry.m {
+		if now.Sub(e.updated) > idtRegistryMaxAge {
+			delete(idtRegistry.m, k)
+		}
+	}
+	idtRegistry.Unlock()
+}
+
+// CurrentIDT returns the latest captured IDT for sessionID, or "" if none.
+func CurrentIDT(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	idtRegistry.RLock()
+	e, ok := idtRegistry.m[sessionID]
+	idtRegistry.RUnlock()
+	if !ok {
+		return ""
+	}
+	return e.idt
+}
+
+// ForgetIDT drops a session's entry. Call on WebSocket close and logout.
+func ForgetIDT(sessionID string) {
+	idtRegistry.Lock()
+	delete(idtRegistry.m, sessionID)
+	idtRegistry.Unlock()
+}

--- a/pkg/gofiber-session/idtregistry_test.go
+++ b/pkg/gofiber-session/idtregistry_test.go
@@ -1,0 +1,35 @@
+package gofiber_session
+
+import "testing"
+
+func TestIDTRegistry_CaptureAndCurrent(t *testing.T) {
+	ForgetIDT("sess-1") // clean slate
+
+	if got := CurrentIDT("sess-1"); got != "" {
+		t.Fatalf("empty registry: want \"\", got %q", got)
+	}
+
+	CaptureIDT("sess-1", "IDT-aaa.cipher")
+	if got := CurrentIDT("sess-1"); got != "IDT-aaa.cipher" {
+		t.Fatalf("after capture: want IDT-aaa.cipher, got %q", got)
+	}
+
+	// Newer capture overwrites.
+	CaptureIDT("sess-1", "IDT-bbb.cipher")
+	if got := CurrentIDT("sess-1"); got != "IDT-bbb.cipher" {
+		t.Fatalf("after second capture: want IDT-bbb.cipher, got %q", got)
+	}
+
+	// Empty inputs are no-ops.
+	CaptureIDT("", "IDT-x")
+	CaptureIDT("sess-1", "")
+	if got := CurrentIDT("sess-1"); got != "IDT-bbb.cipher" {
+		t.Fatalf("empty inputs must not overwrite: got %q", got)
+	}
+
+	// Forget clears it.
+	ForgetIDT("sess-1")
+	if got := CurrentIDT("sess-1"); got != "" {
+		t.Fatalf("after forget: want \"\", got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an in-process IDT registry (`CaptureIDT`/`CurrentIDT`/`ForgetIDT`) so WebSocket handlers can read the *current* inter-app token at publish time instead of a token frozen at handshake — fixes long/active chats dropping ("session-expired") when the session IDT rotates mid-socket.
- Adds reusable `CaptureIDTMiddleware(session)` — the one-line adoption point for webapps to keep the registry warm on normal forwarded traffic.

## Test Plan
- [x] `go test ./...` passes
- [ ] Consumed by powerlineClaimSearchWebApp on Dev; verify long chat survives IDT rotation (no session-expired, outbound idtid changes)